### PR TITLE
Process optimization

### DIFF
--- a/AnonKey-Backend.csproj
+++ b/AnonKey-Backend.csproj
@@ -24,4 +24,10 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <OutputPath>./bin/</OutputPath>
+  </PropertyGroup>
 </Project>

--- a/AnonKey-Backend.csproj
+++ b/AnonKey-Backend.csproj
@@ -30,4 +30,8 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <OutputPath>./bin/</OutputPath>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <AnalysisMode>Recommended</AnalysisMode>
+  </PropertyGroup>
 </Project>

--- a/Configuration/Settings.cs
+++ b/Configuration/Settings.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CA1707
 using Newtonsoft.Json;
 namespace AnonKey_Backend.Configuration;
 

--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,21 @@ installDirectory := /opt/AnonKey/
 publishDirectory := ./publish/
 defaultOptions := 
 compiler := dotnet
+projectName := AnonKey-Backend
 SHELL := /bin/bash
 
 # 
 # Build the project to $(buildDirectory) in default (usually Debug) mode.
 # 
-default:
+build:
+	@echo "[BUILD - INFO] ✅ Attempting to build $(projectName) to $(buildDirectory)..."
 	$(compiler) build $(defaultOptions) -o $(buildDirectory)
 
 #
 # Clean up any auxiliary build files residing in $(buildDirectory) or in $(publishDirectory)
 # 
 clean:
+	@echo "[CLEAN - INFO] ✅ Deleting the contents of $(publishDirectory) and $(buildDirectory)."
 	rm -rf $(buildDirectory)
 	rm -rf $(publishDirectory)
 
@@ -22,24 +25,28 @@ clean:
 # Execute `make clean` and, in addition to that, also delete the current database.
 #
 wipe: clean
+	@echo "[WIPE - INFO] ✅ Deleting database.db."
 	if [[ -f database.db ]]; then rm database.db; fi
 
 #
 # Run the dotnet application on port 5000, and build it if necessary.
 #
-run: 
+run: build 
+	@echo "[RUN - INFO] ✅ Starting the application on port 5000..."
 	ASPNETCORE_HTTP_PORTS=5000 $(compiler) run	
 
 #
 # Run the dotnet appliation on alternate port 5100, and build it if necessary.
 #
-run_alt:
+run_alt: build
+	@echo "[RUN_ALT - INFO] ✅ Starting the application on port 5100..."
 	ASPNETCORE_HTTP_PORTS=5100 $(compiler) run	
 
 #
 # Publish the dotnet application to $(publishDirecotry).
 #
 publish:
+	@echo "[PUBLISH - INFO] ✅ Attempting to publish $(projectName) to $(buildDirectory)..."
 	$(compiler) publish -o $(publishDirectory)
 
 
@@ -48,6 +55,7 @@ publish:
 # WARNING: This will run `make wipe`, `make uninstall` and `make publish` accordingly!
 #
 install: wipe uninstall publish
+	@echo "[INSTALL - INFO] ✅ Attempting to install $(projectName) to $(installDirectory) ..."
 	if [[ ! -d $(installDirectory) ]]; then mkdir $(installDirectory); fi
 	cp -r publish/* $(installDirectory) 
 	cp AnonKey.service /etc/systemd/system/
@@ -60,6 +68,7 @@ install: wipe uninstall publish
 # WARNING: This will run `make wipe`, `make uninstall` and `make publish` accordingly!
 #
 install-debug: wipe uninstall publish 
+	@echo "[INSTALL-DEBUG - INFO] ✅ Attempting to install debug version of $(projectName) to $(installDirectory) ..."
 	if [[ ! -d $(installDirectory) ]]; then mkdir $(installDirectory); fi
 	cp -r publish/* $(installDirectory) 
 	cp AnonKey-Debug.service /etc/systemd/system/
@@ -72,6 +81,7 @@ install-debug: wipe uninstall publish
 # WARNING: This will also delete the database!
 #
 uninstall:
+	@echo "[UNINSTALL - INFO] ✅ Attempting to uninstall $(projectName) from $(installDirectory) ..."
 	if [[ -f /etc/systemd/system/AnonKey.service ]]; then systemctl is-active AnonKey.Service && systemctl stop AnonKey.service; systemctl disable AnonKey.service; rm /etc/systemd/system/AnonKey.service; fi
 	if [[ -f /etc/systemd/system/AnonKey-Debug.service ]]; then systemctl is-active AnonKey.Service && systemctl stop AnonKey-Debug.service; systemctl disable AnonKey-Debug.service; rm /etc/systemd/system/AnonKey-Debug.service; fi
 	rm -rf $(installDirectory)
@@ -81,4 +91,12 @@ uninstall:
 #
 .PHONY: docs
 docs:
+	@echo "[DOCS - INFO] ✅ Attempting to build $(projectName) documentation..."
 	doxygen doxygen.conf
+
+### The following profiles are project-specific preflight checks used to ensure consistent code.
+
+preflight-pull:
+	@echo "[PREFLIGHT-PULL - INFO] ✅ Running Preflight checks for a Pull Request..."
+	@echo "[PREFLIGHT-PULL - INFO] 💬 Checking for uncommited changes..."
+

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,20 @@ docs:
 	@echo "[DOCS - INFO] 💬 Attempting to build $(projectName) documentation..."
 	doxygen doxygen.conf
 
+#
+# Push local commits to the remote repository.
+#
+push: preflight-push
+	@echo "[PUSH - INFO] Pushing local commits to the remote..."
+	git push
+
+
 ### The following profiles are project-specific preflight checks used to ensure consistent code.
+
+preflight-push:
+	@echo "[PREFLIGHT-PUSH - INFO] ✅ Running preflight-checks for a push..."
+	@make -s preflight-not-main
+	@echo "[PREFLIGHT-PUSH - PASS] ✅ All preflight-checks for a push have passed!"
 
 preflight-pull:
 	@echo "[PREFLIGHT-PULL - INFO] ✅ Running preflight-checks for a Pull Request..."
@@ -132,6 +145,4 @@ preflight-compilation: clean-silent
 preflight-warnings: clean-silent
 	@echo "[PREFLIGHT-WARNINGS - INFO] 💬 Checking if there are any Warnings during compile-time..."
 	@if dotnet build /WarnAsError | grep -q "Build succeeded."; then echo "[PREFLIGHT-WARNINGS - PASS] ✅ Project does not produce any warnings."; else echo "[PREFLIGHT-WARNINGS - WARN] ❓ The project produces compiler warnings. Please review the warnings using 'make clean' and 'make build' before opening a pull request!"; fi 
-
-
 

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,52 @@
-buildDirectory := bin
+buildDirectory := ./bin/
 installDirectory := /opt/AnonKey/
-publishDirectory := publish
+publishDirectory := ./publish/
 defaultOptions := 
 compiler := dotnet
 SHELL := /bin/bash
 
+# 
+# Build the project to $(buildDirectory) in default (usually Debug) mode.
+# 
 default:
 	$(compiler) build $(defaultOptions) -o $(buildDirectory)
 
+#
+# Clean up any auxiliary build files residing in $(buildDirectory) or in $(publishDirectory)
+# 
 clean:
 	rm -rf $(buildDirectory)
 	rm -rf $(publishDirectory)
 
+#
+# Execute `make clean` and, in addition to that, also delete the current database.
+#
 wipe: clean
 	if [[ -f database.db ]]; then rm database.db; fi
 
+#
+# Run the dotnet application on port 5000, and build it if necessary.
+#
 run: 
 	ASPNETCORE_HTTP_PORTS=5000 $(compiler) run	
 
+#
+# Run the dotnet appliation on alternate port 5100, and build it if necessary.
+#
 run_alt:
 	ASPNETCORE_HTTP_PORTS=5100 $(compiler) run	
 
+#
+# Publish the dotnet application to $(publishDirecotry).
+#
 publish:
 	$(compiler) publish -o $(publishDirectory)
 
+
+#
+# Install the application to $(installDirectory). 
+# WARNING: This will run `make wipe`, `make uninstall` and `make publish` accordingly!
+#
 install: wipe uninstall publish
 	if [[ ! -d $(installDirectory) ]]; then mkdir $(installDirectory); fi
 	cp -r publish/* $(installDirectory) 
@@ -32,6 +55,10 @@ install: wipe uninstall publish
 	@echo "Installed AnonKey to /opt/AnonKey. Start Systemd Unit AnonKey.service to run the application!"
 	@echo "The application uses TCP port 5000."
 
+#
+# Install the application in debug mode to $(installDirectory). 
+# WARNING: This will run `make wipe`, `make uninstall` and `make publish` accordingly!
+#
 install-debug: wipe uninstall publish 
 	if [[ ! -d $(installDirectory) ]]; then mkdir $(installDirectory); fi
 	cp -r publish/* $(installDirectory) 
@@ -40,10 +67,18 @@ install-debug: wipe uninstall publish
 	@echo "Installed debug version of AnonKey to /opt/AnonKey. Start Systemd Unit AnonKey-Debug.service to run the application!"
 	@echo "The application uses TCP port 5000."
 
+#
+# This will uninstall the application from $(installDirectory) and stop all related services.
+# WARNING: This will also delete the database!
+#
 uninstall:
 	if [[ -f /etc/systemd/system/AnonKey.service ]]; then systemctl is-active AnonKey.Service && systemctl stop AnonKey.service; systemctl disable AnonKey.service; rm /etc/systemd/system/AnonKey.service; fi
 	if [[ -f /etc/systemd/system/AnonKey-Debug.service ]]; then systemctl is-active AnonKey.Service && systemctl stop AnonKey-Debug.service; systemctl disable AnonKey-Debug.service; rm /etc/systemd/system/AnonKey-Debug.service; fi
 	rm -rf $(installDirectory)
+
+#
+# Build the documentation using doxygen to ./docs/
+#
 .PHONY: docs
 docs:
 	doxygen doxygen.conf

--- a/Makefile
+++ b/Makefile
@@ -6,47 +6,60 @@ compiler := dotnet
 projectName := AnonKey-Backend
 SHELL := /bin/bash
 
+
+
+.PHONY: docs
+
+.SILENT: clean-silent
+
 # 
 # Build the project to $(buildDirectory) in default (usually Debug) mode.
 # 
 build:
-	@echo "[BUILD - INFO] ✅ Attempting to build $(projectName) to $(buildDirectory)..."
+	@echo "[BUILD - INFO] 💬 Attempting to build $(projectName) to $(buildDirectory)..."
 	$(compiler) build $(defaultOptions) -o $(buildDirectory)
 
 #
 # Clean up any auxiliary build files residing in $(buildDirectory) or in $(publishDirectory)
 # 
 clean:
-	@echo "[CLEAN - INFO] ✅ Deleting the contents of $(publishDirectory) and $(buildDirectory)."
+	@echo "[CLEAN - INFO] 💬 Deleting the contents of $(publishDirectory), ./obj/ and $(buildDirectory)."
 	rm -rf $(buildDirectory)
 	rm -rf $(publishDirectory)
+	rm -rf ./obj/
+
+clean-silent:
+	@echo "[CLEAN - INFO] 🔄 Deleting the contents of $(publishDirectory), ./obj/ and $(buildDirectory)."
+	@rm -rf $(buildDirectory)
+	@rm -rf $(publishDirectory)
+	@rm -rf ./obj/
 
 #
 # Execute `make clean` and, in addition to that, also delete the current database.
 #
 wipe: clean
-	@echo "[WIPE - INFO] ✅ Deleting database.db."
+	@echo "[WIPE - INFO] 💬 Deleting database.db."
 	if [[ -f database.db ]]; then rm database.db; fi
 
 #
 # Run the dotnet application on port 5000, and build it if necessary.
 #
 run: build 
-	@echo "[RUN - INFO] ✅ Starting the application on port 5000..."
+	@echo "[RUN - INFO] 💬 Starting the application on port 5000..."
 	ASPNETCORE_HTTP_PORTS=5000 $(compiler) run	
 
 #
 # Run the dotnet appliation on alternate port 5100, and build it if necessary.
 #
 run_alt: build
-	@echo "[RUN_ALT - INFO] ✅ Starting the application on port 5100..."
+	@echo "[RUN_ALT - INFO] 💬 Starting the application on port 5100..."
 	ASPNETCORE_HTTP_PORTS=5100 $(compiler) run	
 
 #
 # Publish the dotnet application to $(publishDirecotry).
 #
 publish:
-	@echo "[PUBLISH - INFO] ✅ Attempting to publish $(projectName) to $(buildDirectory)..."
+	@echo "[PUBLISH - INFO] 💬 Attempting to publish $(projectName) to $(buildDirectory)..."
 	$(compiler) publish -o $(publishDirectory)
 
 
@@ -55,7 +68,7 @@ publish:
 # WARNING: This will run `make wipe`, `make uninstall` and `make publish` accordingly!
 #
 install: wipe uninstall publish
-	@echo "[INSTALL - INFO] ✅ Attempting to install $(projectName) to $(installDirectory) ..."
+	@echo "[INSTALL - INFO] 💬 Attempting to install $(projectName) to $(installDirectory) ..."
 	if [[ ! -d $(installDirectory) ]]; then mkdir $(installDirectory); fi
 	cp -r publish/* $(installDirectory) 
 	cp AnonKey.service /etc/systemd/system/
@@ -68,7 +81,7 @@ install: wipe uninstall publish
 # WARNING: This will run `make wipe`, `make uninstall` and `make publish` accordingly!
 #
 install-debug: wipe uninstall publish 
-	@echo "[INSTALL-DEBUG - INFO] ✅ Attempting to install debug version of $(projectName) to $(installDirectory) ..."
+	@echo "[INSTALL-DEBUG - INFO] 💬 Attempting to install debug version of $(projectName) to $(installDirectory) ..."
 	if [[ ! -d $(installDirectory) ]]; then mkdir $(installDirectory); fi
 	cp -r publish/* $(installDirectory) 
 	cp AnonKey-Debug.service /etc/systemd/system/
@@ -81,7 +94,7 @@ install-debug: wipe uninstall publish
 # WARNING: This will also delete the database!
 #
 uninstall:
-	@echo "[UNINSTALL - INFO] ✅ Attempting to uninstall $(projectName) from $(installDirectory) ..."
+	@echo "[UNINSTALL - INFO] 💬 Attempting to uninstall $(projectName) from $(installDirectory) ..."
 	if [[ -f /etc/systemd/system/AnonKey.service ]]; then systemctl is-active AnonKey.Service && systemctl stop AnonKey.service; systemctl disable AnonKey.service; rm /etc/systemd/system/AnonKey.service; fi
 	if [[ -f /etc/systemd/system/AnonKey-Debug.service ]]; then systemctl is-active AnonKey.Service && systemctl stop AnonKey-Debug.service; systemctl disable AnonKey-Debug.service; rm /etc/systemd/system/AnonKey-Debug.service; fi
 	rm -rf $(installDirectory)
@@ -89,14 +102,36 @@ uninstall:
 #
 # Build the documentation using doxygen to ./docs/
 #
-.PHONY: docs
 docs:
-	@echo "[DOCS - INFO] ✅ Attempting to build $(projectName) documentation..."
+	@echo "[DOCS - INFO] 💬 Attempting to build $(projectName) documentation..."
 	doxygen doxygen.conf
 
 ### The following profiles are project-specific preflight checks used to ensure consistent code.
 
 preflight-pull:
-	@echo "[PREFLIGHT-PULL - INFO] ✅ Running Preflight checks for a Pull Request..."
-	@echo "[PREFLIGHT-PULL - INFO] 💬 Checking for uncommited changes..."
+	@echo "[PREFLIGHT-PULL - INFO] ✅ Running preflight-checks for a Pull Request..."
+	@make -s preflight-not-main
+	@make -s preflight-clean
+	@make -s preflight-format
+	@make -s preflight-compilation
+	@make -s preflight-warnings
+	@echo "[PREFLIGHT-PULL - PASS] ✅ All preflight-checks for a Pull Request have passed!"
+
+preflight-not-main:
+	@echo "[PREFLIGHT-NOT-MAIN - INFO] 💬 Making sure the current branch is not main..."
+	@if ! git symbolic-ref -q HEAD | grep -q "/main$$"; then echo "[PREFLIGHT-NOT-MAIN - PASS] ✅ Your current branch is not main."; else echo "[PREFLIGHT-NOT-MAIN - FAIL] ❌ You are working on the main branch!"; exit 1; fi 
+preflight-clean:
+	@echo "[PREFLIGHT-CLEAN - INFO] 💬 Checking for uncommited changes..."
+	@if [[ -z "$$(git status --porcelain=v1)" ]]; then echo "[PREFLIGHT-CLEAN - PASS] ✅ Working tree appears clean!"; else echo "[PREFLIGHT-CLEAN - FAIL] ❌ The working tree is not clean. Please commit your changes!"; exit 1; fi
+preflight-format: preflight-clean 
+	@echo "[PREFLIGHT-FORMAT - INFO] 💬 Checking project formatting..."
+	@dotnet format; if [[ -z "$$(git status --porcelain=v1)" ]]; then echo "[PREFLIGHT-FORMAT - PASS] ✅ Project appears to be formatted correctly!"; else echo "[PREFLIGHT-FORMAT - FAIL] ❌ The project is not properly formatted! Please review the automatic formatting, and then commit the changes."; exit 1; fi
+preflight-compilation: clean-silent
+	@echo "[PREFLIGHT-COMPILATION - INFO] 💬 Checking if the project compiles..."
+	@if dotnet build | grep -q "Build succeeded."; then echo "[PREFLIGHT-COMPILATION - PASS] ✅ Project compiles successfully."; else echo "[PREFLIGHT-COMPILATION - FAIL] ❌ The project did not compile successfully! Please try building it again and make sure your changes are working!"; exit 1; fi 
+preflight-warnings: clean-silent
+	@echo "[PREFLIGHT-WARNINGS - INFO] 💬 Checking if there are any Warnings during compile-time..."
+	@if dotnet build /WarnAsError | grep -q "Build succeeded."; then echo "[PREFLIGHT-WARNINGS - PASS] ✅ Project does not produce any warnings."; else echo "[PREFLIGHT-WARNINGS - WARN] ❓ The project produces compiler warnings. Please review the warnings using 'make clean' and 'make build' before opening a pull request!"; fi 
+
+
 


### PR DESCRIPTION
- Builds now always go to ./bin/, instead of only when built through make
- Added documentation to the makefile
- Enabled warnings for Roslyn Code Analysis results, resulting in styling warnings (To be fixed in refactoring!)
- Added output to the makefile targets
- Added preflight checks (check bottom of makefile)
- Added a preflight-check profile for pull requests
- Added a make push target that automatically runs the preflight-not-main check
- Disabled a styling warning in Settings, since that one is known, but not fixable