### PR TITLE
Renamed the project root namespace to align with naming conventions

### DIFF
--- a/AnonKey-Backend.csproj
+++ b/AnonKey-Backend.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
-    <RootNamespace>AnonKey_Backend</RootNamespace>
+    <RootNamespace>AnonKeyBackend</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ApiDatastructures/Authentication/Login/AuthenticationLoginRequestBody.cs
+++ b/ApiDatastructures/Authentication/Login/AuthenticationLoginRequestBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Authentication.Login;
+namespace AnonKeyBackend.ApiDatastructures.Authentication.Login;
 
 /// <summary>
 /// The body of a login request.

--- a/ApiDatastructures/Authentication/Login/AuthenticationLoginResponseBody.cs
+++ b/ApiDatastructures/Authentication/Login/AuthenticationLoginResponseBody.cs
@@ -1,5 +1,5 @@
 
-namespace AnonKey_Backend.ApiDatastructures.Authentication.Login;
+namespace AnonKeyBackend.ApiDatastructures.Authentication.Login;
 
 /// <summary>
 /// The body of the response to a login request.

--- a/ApiDatastructures/Authentication/changePassword/AuthenticationChangePasswordRequestBody.cs
+++ b/ApiDatastructures/Authentication/changePassword/AuthenticationChangePasswordRequestBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Authentication.ChangePassword;
+namespace AnonKeyBackend.ApiDatastructures.Authentication.ChangePassword;
 
 /// <summary>
 /// The body of a password change request.

--- a/ApiDatastructures/Credentials/Create/CredentialsCreateCredential.cs
+++ b/ApiDatastructures/Credentials/Create/CredentialsCreateCredential.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Credentials.Create;
+namespace AnonKeyBackend.ApiDatastructures.Credentials.Create;
 
 /// <summary>
 /// The credential object inside a credential create request.

--- a/ApiDatastructures/Credentials/Create/CredentialsCreateRequestBody.cs
+++ b/ApiDatastructures/Credentials/Create/CredentialsCreateRequestBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Credentials.Create;
+namespace AnonKeyBackend.ApiDatastructures.Credentials.Create;
 
 /// <summary>
 /// The body of a credential create request.

--- a/ApiDatastructures/Credentials/Get/CredentialsGetCredential.cs
+++ b/ApiDatastructures/Credentials/Get/CredentialsGetCredential.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Credentials.Get;
+namespace AnonKeyBackend.ApiDatastructures.Credentials.Get;
 
 /// <summary>
 /// Credential in a credential get response.

--- a/ApiDatastructures/Credentials/Get/CredentialsGetResponseBody.cs
+++ b/ApiDatastructures/Credentials/Get/CredentialsGetResponseBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Credentials.Get;
+namespace AnonKeyBackend.ApiDatastructures.Credentials.Get;
 
 /// <summary>
 /// The body of a response to a credential get request.

--- a/ApiDatastructures/Credentials/GetAll/CredentialsGetAllCredential.cs
+++ b/ApiDatastructures/Credentials/GetAll/CredentialsGetAllCredential.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Credentials.GetAll;
+namespace AnonKeyBackend.ApiDatastructures.Credentials.GetAll;
 
 /// <summary>
 /// The credentials inside the list returned by a get all credentials request. 

--- a/ApiDatastructures/Credentials/GetAll/CredentialsGetAllResponseBody.cs
+++ b/ApiDatastructures/Credentials/GetAll/CredentialsGetAllResponseBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Credentials.GetAll;
+namespace AnonKeyBackend.ApiDatastructures.Credentials.GetAll;
 
 /// <summary>
 /// Response to a get all credentials request.

--- a/ApiDatastructures/Credentials/Update/CredentialsUpdateCredentialRequest.cs
+++ b/ApiDatastructures/Credentials/Update/CredentialsUpdateCredentialRequest.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Credentials.Update;
+namespace AnonKeyBackend.ApiDatastructures.Credentials.Update;
 
 /// <summary>
 /// The credential inside a credential update request.

--- a/ApiDatastructures/Credentials/Update/CredentialsUpdateCredentialResponse.cs
+++ b/ApiDatastructures/Credentials/Update/CredentialsUpdateCredentialResponse.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Credentials.Update;
+namespace AnonKeyBackend.ApiDatastructures.Credentials.Update;
 
 /// <summary>
 /// The response to a credential update operation.

--- a/ApiDatastructures/Credentials/Update/CredentialsUpdateRequestBody.cs
+++ b/ApiDatastructures/Credentials/Update/CredentialsUpdateRequestBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Credentials.Update;
+namespace AnonKeyBackend.ApiDatastructures.Credentials.Update;
 
 /// <summary>
 /// The body of a credential update request.

--- a/ApiDatastructures/Credentials/Update/CredentialsUpdateResponseBody.cs
+++ b/ApiDatastructures/Credentials/Update/CredentialsUpdateResponseBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Credentials.Update;
+namespace AnonKeyBackend.ApiDatastructures.Credentials.Update;
 
 /// <summary>
 /// The body of a credential update response.

--- a/ApiDatastructures/Error/ErrorResponseBody.cs
+++ b/ApiDatastructures/Error/ErrorResponseBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Error;
+namespace AnonKeyBackend.ApiDatastructures.Error;
 
 /// <summary>
 /// Structure of an error message.

--- a/ApiDatastructures/Folders/Create/FoldersCreateFolder.cs
+++ b/ApiDatastructures/Folders/Create/FoldersCreateFolder.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Folders.Create;
+namespace AnonKeyBackend.ApiDatastructures.Folders.Create;
 
 /// <summary>
 /// Folder contained inside a create folder operation.

--- a/ApiDatastructures/Folders/Create/FoldersCreateRequestBody.cs
+++ b/ApiDatastructures/Folders/Create/FoldersCreateRequestBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Folders.Create;
+namespace AnonKeyBackend.ApiDatastructures.Folders.Create;
 
 /// <summary>
 /// Body of a folder create request.

--- a/ApiDatastructures/Folders/Create/FoldersCreateResponseBody.cs
+++ b/ApiDatastructures/Folders/Create/FoldersCreateResponseBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Folders.Create;
+namespace AnonKeyBackend.ApiDatastructures.Folders.Create;
 
 /// <summary>
 /// Response to a folder create request.

--- a/ApiDatastructures/Folders/Get/FoldersGetFolder.cs
+++ b/ApiDatastructures/Folders/Get/FoldersGetFolder.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Folders.Get;
+namespace AnonKeyBackend.ApiDatastructures.Folders.Get;
 
 /// <summary>
 /// Folder in a folder get response.

--- a/ApiDatastructures/Folders/Get/FoldersGetResponseBody.cs
+++ b/ApiDatastructures/Folders/Get/FoldersGetResponseBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Folders.Get;
+namespace AnonKeyBackend.ApiDatastructures.Folders.Get;
 
 /// <summary>
 /// Response to a folder get request.

--- a/ApiDatastructures/Folders/GetAll/FoldersGetAllFolder.cs
+++ b/ApiDatastructures/Folders/GetAll/FoldersGetAllFolder.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Folders.GetAll;
+namespace AnonKeyBackend.ApiDatastructures.Folders.GetAll;
 
 /// <summary>
 /// Folder in a response to a get all folders request.

--- a/ApiDatastructures/Folders/GetAll/FoldersGetAllResponseBody.cs
+++ b/ApiDatastructures/Folders/GetAll/FoldersGetAllResponseBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Folders.GetAll;
+namespace AnonKeyBackend.ApiDatastructures.Folders.GetAll;
 
 /// <summary>
 /// Response to a get all folders request.

--- a/ApiDatastructures/Folders/Update/FoldersUpdateFolder.cs
+++ b/ApiDatastructures/Folders/Update/FoldersUpdateFolder.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Folders.Update;
+namespace AnonKeyBackend.ApiDatastructures.Folders.Update;
 
 /// <summary>
 /// Folder returned by the update request.

--- a/ApiDatastructures/Folders/Update/FoldersUpdateRequestBody.cs
+++ b/ApiDatastructures/Folders/Update/FoldersUpdateRequestBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Folders.Update;
+namespace AnonKeyBackend.ApiDatastructures.Folders.Update;
 
 /// <summary>
 /// The body of a folder update request.

--- a/ApiDatastructures/Folders/Update/FoldersUpdateResponseBody.cs
+++ b/ApiDatastructures/Folders/Update/FoldersUpdateResponseBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Folders.Update;
+namespace AnonKeyBackend.ApiDatastructures.Folders.Update;
 
 /// <summary>
 /// Body of a response to a folder update request.

--- a/ApiDatastructures/Users/Create/UsersCreateRequestBody.cs
+++ b/ApiDatastructures/Users/Create/UsersCreateRequestBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Users.Create;
+namespace AnonKeyBackend.ApiDatastructures.Users.Create;
 
 /// <summary>
 /// Body of a user create request.

--- a/ApiDatastructures/Users/Create/UsersCreateResponseBody.cs
+++ b/ApiDatastructures/Users/Create/UsersCreateResponseBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Users.Create;
+namespace AnonKeyBackend.ApiDatastructures.Users.Create;
 
 /// <summary>
 /// Body of a response to a user create request.

--- a/ApiDatastructures/Users/Get/UsersGetResponseBody.cs
+++ b/ApiDatastructures/Users/Get/UsersGetResponseBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Users.Get;
+namespace AnonKeyBackend.ApiDatastructures.Users.Get;
 
 /// <summary>
 /// Response body of a user get request.

--- a/ApiDatastructures/Users/Get/UsersGetUser.cs
+++ b/ApiDatastructures/Users/Get/UsersGetUser.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Users.Get;
+namespace AnonKeyBackend.ApiDatastructures.Users.Get;
 
 /// <summary>
 /// User requested.

--- a/ApiDatastructures/Users/Update/UsersUpdateRequestBody.cs
+++ b/ApiDatastructures/Users/Update/UsersUpdateRequestBody.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Users.Update;
+namespace AnonKeyBackend.ApiDatastructures.Users.Update;
 
 /// <summary>
 /// Body of a user update request.

--- a/ApiDatastructures/Users/Update/UsersUpdateUser.cs
+++ b/ApiDatastructures/Users/Update/UsersUpdateUser.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiDatastructures.Users.Update;
+namespace AnonKeyBackend.ApiDatastructures.Users.Update;
 
 /// <summary>
 /// User update request user.

--- a/ApiEndpoints/Authentication/ChangePassword.cs
+++ b/ApiEndpoints/Authentication/ChangePassword.cs
@@ -1,7 +1,7 @@
-using AnonKey_Backend.Data;
-using AnonKey_Backend.Models;
+using AnonKeyBackend.Data;
+using AnonKeyBackend.Models;
 
-namespace AnonKey_Backend.ApiEndpoints.Authentication;
+namespace AnonKeyBackend.ApiEndpoints.Authentication;
 
 /// <summary>
 /// Changes a users password.

--- a/ApiEndpoints/Authentication/EndpointSetup.cs
+++ b/ApiEndpoints/Authentication/EndpointSetup.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiEndpoints.Authentication;
+namespace AnonKeyBackend.ApiEndpoints.Authentication;
 
 /// <summary>
 /// Maps the endpoint paths to the appropriate methods for the Authentication endpoint  

--- a/ApiEndpoints/Authentication/Login.cs
+++ b/ApiEndpoints/Authentication/Login.cs
@@ -1,6 +1,6 @@
-using AnonKey_Backend.Models;
+using AnonKeyBackend.Models;
 
-namespace AnonKey_Backend.ApiEndpoints.Authentication;
+namespace AnonKeyBackend.ApiEndpoints.Authentication;
 
 /// <summary>
 /// Handles the authentication login endpoint.
@@ -15,7 +15,7 @@ public static class Login
         Ok<ApiDatastructures.Authentication.Login.AuthenticationLoginResponseBody>,
         NotFound<ApiDatastructures.Error.ErrorResponseBody>,
         BadRequest<ApiDatastructures.Error.ErrorResponseBody>>
-            PostLogin(ApiDatastructures.Authentication.Login.AuthenticationLoginRequestBody requestBody, AnonKey_Backend.Authentication.TokenService tokenService, Data.DatabaseHandle databaseHandle)
+            PostLogin(ApiDatastructures.Authentication.Login.AuthenticationLoginRequestBody requestBody, AnonKeyBackend.Authentication.TokenService tokenService, Data.DatabaseHandle databaseHandle)
     {
         databaseHandle.Database.EnsureCreated();
 
@@ -54,7 +54,7 @@ public static class Login
         return TypedResults.Ok(new ApiDatastructures.Authentication.Login.AuthenticationLoginResponseBody
         {
             Token = token,
-            ExpiresInSeconds = AnonKey_Backend.Authentication.TokenService.TokenExpiryGraceInSeconds
+            ExpiresInSeconds = AnonKeyBackend.Authentication.TokenService.TokenExpiryGraceInSeconds
         });
     }
 }

--- a/ApiEndpoints/Credentials/Create.cs
+++ b/ApiEndpoints/Credentials/Create.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiEndpoints.Credentials;
+namespace AnonKeyBackend.ApiEndpoints.Credentials;
 
 /// <summary>
 /// Handles the credentials creation endpoint.
@@ -97,7 +97,7 @@ public static class Create
     private static Models.Credential CreateNewCredential(ApiDatastructures.Credentials.Create.CredentialsCreateRequestBody requestBody, string? username, Data.DatabaseHandle databaseHandle)
     {
         if (username is null || requestBody.Credential is null) throw new ArgumentNullException();
-        AnonKey_Backend.Models.User? FetchedUser = databaseHandle.Users.SingleOrDefault(u => u.Username == username);
+        AnonKeyBackend.Models.User? FetchedUser = databaseHandle.Users.SingleOrDefault(u => u.Username == username);
         if (FetchedUser is null) throw new NullReferenceException("There is no user with this username in the database.");
         return new Models.Credential()
         {

--- a/ApiEndpoints/Credentials/Delete.cs
+++ b/ApiEndpoints/Credentials/Delete.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiEndpoints.Credentials;
+namespace AnonKeyBackend.ApiEndpoints.Credentials;
 
 /// <summary>
 /// Handles the credentials delete endpoint.
@@ -32,7 +32,7 @@ public static class Delete
             });
         }
 
-        AnonKey_Backend.Models.Credential? FetchedCredential = databaseHandle.Credentials.SingleOrDefault(c => c.Uuid == credentialUuid && c.UserUuid == databaseHandle.Users.Single(u => u.Username == user.Identity.Name).Uuid && c.DeletedTimestamp != null);
+        AnonKeyBackend.Models.Credential? FetchedCredential = databaseHandle.Credentials.SingleOrDefault(c => c.Uuid == credentialUuid && c.UserUuid == databaseHandle.Users.Single(u => u.Username == user.Identity.Name).Uuid && c.DeletedTimestamp != null);
 
         if (FetchedCredential is null)
         {

--- a/ApiEndpoints/Credentials/EndpointSetup.cs
+++ b/ApiEndpoints/Credentials/EndpointSetup.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiEndpoints.Credentials;
+namespace AnonKeyBackend.ApiEndpoints.Credentials;
 
 /// <summary>
 /// Handles mapping the credentials endpoints.

--- a/ApiEndpoints/Credentials/Get.cs
+++ b/ApiEndpoints/Credentials/Get.cs
@@ -1,7 +1,7 @@
-using AnonKey_Backend.ApiDatastructures.Credentials.Get;
-using AnonKey_Backend.Models;
+using AnonKeyBackend.ApiDatastructures.Credentials.Get;
+using AnonKeyBackend.Models;
 
-namespace AnonKey_Backend.ApiEndpoints.Credentials;
+namespace AnonKeyBackend.ApiEndpoints.Credentials;
 
 /// <summary>
 /// Handles the credentials get endpoint.
@@ -62,7 +62,7 @@ public static class Get
         if (FetchedCredential is null) throw new ArgumentNullException();
         return new ApiDatastructures.Credentials.Get.CredentialsGetResponseBody()
         {
-            Credential = new AnonKey_Backend.ApiDatastructures.Credentials.Get.CredentialsGetCredential()
+            Credential = new AnonKeyBackend.ApiDatastructures.Credentials.Get.CredentialsGetCredential()
             {
                 Uuid = FetchedCredential.Uuid,
                 Password = FetchedCredential.Password,

--- a/ApiEndpoints/Credentials/GetAll.cs
+++ b/ApiEndpoints/Credentials/GetAll.cs
@@ -1,7 +1,7 @@
-using AnonKey_Backend.ApiDatastructures.Credentials.GetAll;
-using AnonKey_Backend.Data;
+using AnonKeyBackend.ApiDatastructures.Credentials.GetAll;
+using AnonKeyBackend.Data;
 
-namespace AnonKey_Backend.ApiEndpoints.Credentials;
+namespace AnonKeyBackend.ApiEndpoints.Credentials;
 
 /// <summary>
 /// Handles the credentials get all endpoint.
@@ -35,14 +35,14 @@ public static class GetAll
     private static CredentialsGetAllResponseBody GetAllCredetials(string? username, DatabaseHandle databaseHandle)
     {
         if (username is null) throw new ArgumentNullException();
-        AnonKey_Backend.Models.User? FetchedUser = databaseHandle.Users.SingleOrDefault(u => u.Username == username);
+        AnonKeyBackend.Models.User? FetchedUser = databaseHandle.Users.SingleOrDefault(u => u.Username == username);
         if (FetchedUser is null) throw new NullReferenceException("There is no user with this username in the database.");
-        List<AnonKey_Backend.Models.Credential> FetchedCredetials = databaseHandle.Credentials.Where(c => c.UserUuid == FetchedUser.Uuid).ToList();
-        AnonKey_Backend.ApiDatastructures.Credentials.GetAll.CredentialsGetAllResponseBody Result = new AnonKey_Backend.ApiDatastructures.Credentials.GetAll.CredentialsGetAllResponseBody();
-        Result.Credentials = new List<AnonKey_Backend.ApiDatastructures.Credentials.GetAll.CredentialsGetAllCredential>();
-        foreach (AnonKey_Backend.Models.Credential FetchedCredential in FetchedCredetials)
+        List<AnonKeyBackend.Models.Credential> FetchedCredetials = databaseHandle.Credentials.Where(c => c.UserUuid == FetchedUser.Uuid).ToList();
+        AnonKeyBackend.ApiDatastructures.Credentials.GetAll.CredentialsGetAllResponseBody Result = new AnonKeyBackend.ApiDatastructures.Credentials.GetAll.CredentialsGetAllResponseBody();
+        Result.Credentials = new List<AnonKeyBackend.ApiDatastructures.Credentials.GetAll.CredentialsGetAllCredential>();
+        foreach (AnonKeyBackend.Models.Credential FetchedCredential in FetchedCredetials)
         {
-            Result.Credentials.Add(new AnonKey_Backend.ApiDatastructures.Credentials.GetAll.CredentialsGetAllCredential()
+            Result.Credentials.Add(new AnonKeyBackend.ApiDatastructures.Credentials.GetAll.CredentialsGetAllCredential()
             {
                 Uuid = FetchedCredential.Uuid,
                 Password = FetchedCredential.Password,

--- a/ApiEndpoints/Credentials/SoftDelete.cs
+++ b/ApiEndpoints/Credentials/SoftDelete.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiEndpoints.Credentials;
+namespace AnonKeyBackend.ApiEndpoints.Credentials;
 
 /// <summary>
 /// Handles the credentials soft-delete endpoint.
@@ -32,7 +32,7 @@ public static class SoftDelete
             });
         }
 
-        AnonKey_Backend.Models.Credential? FetchedCredential = databaseHandle.Credentials.SingleOrDefault(c => c.Uuid == credentialUuid && c.UserUuid == databaseHandle.Users.Single(u => u.Username == user.Identity.Name).Uuid && c.DeletedTimestamp == null);
+        AnonKeyBackend.Models.Credential? FetchedCredential = databaseHandle.Credentials.SingleOrDefault(c => c.Uuid == credentialUuid && c.UserUuid == databaseHandle.Users.Single(u => u.Username == user.Identity.Name).Uuid && c.DeletedTimestamp == null);
 
         if (FetchedCredential is null)
         {

--- a/ApiEndpoints/Credentials/SoftUndelete.cs
+++ b/ApiEndpoints/Credentials/SoftUndelete.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiEndpoints.Credentials;
+namespace AnonKeyBackend.ApiEndpoints.Credentials;
 
 /// <summary>
 /// Handles the credentials soft-undelete endpoint.
@@ -32,7 +32,7 @@ public static class SoftUndelete
             });
         }
 
-        AnonKey_Backend.Models.Credential? FetchedCredential = databaseHandle.Credentials.SingleOrDefault(c => c.Uuid == credentialUuid && c.UserUuid == databaseHandle.Users.Single(u => u.Username == user.Identity.Name).Uuid && c.DeletedTimestamp != null);
+        AnonKeyBackend.Models.Credential? FetchedCredential = databaseHandle.Credentials.SingleOrDefault(c => c.Uuid == credentialUuid && c.UserUuid == databaseHandle.Users.Single(u => u.Username == user.Identity.Name).Uuid && c.DeletedTimestamp != null);
 
         if (FetchedCredential is null)
         {

--- a/ApiEndpoints/Credentials/Update.cs
+++ b/ApiEndpoints/Credentials/Update.cs
@@ -1,7 +1,7 @@
-using AnonKey_Backend.ApiDatastructures.Credentials.Update;
-using AnonKey_Backend.Models;
+using AnonKeyBackend.ApiDatastructures.Credentials.Update;
+using AnonKeyBackend.Models;
 
-namespace AnonKey_Backend.ApiEndpoints.Credentials;
+namespace AnonKeyBackend.ApiEndpoints.Credentials;
 
 /// <summary>
 /// Handles the editing of credentials.
@@ -75,8 +75,8 @@ public static class Update
         }
 
 
-        AnonKey_Backend.Models.Credential? FetchedCredential = databaseHandle.Credentials.SingleOrDefault(c => c.Uuid == requestBody.Credential.Uuid);
-        AnonKey_Backend.Models.User? FetchedUser = databaseHandle.Users.SingleOrDefault(u => u.Username == user.Identity.Name);
+        AnonKeyBackend.Models.Credential? FetchedCredential = databaseHandle.Credentials.SingleOrDefault(c => c.Uuid == requestBody.Credential.Uuid);
+        AnonKeyBackend.Models.User? FetchedUser = databaseHandle.Users.SingleOrDefault(u => u.Username == user.Identity.Name);
 
         if (FetchedCredential is null)
         {
@@ -109,15 +109,15 @@ public static class Update
 
         UpdateCredential(requestBody, user, UserUuid, FetchedCredential);
         databaseHandle.SaveChanges();
-        AnonKey_Backend.Models.Credential NewCredential = databaseHandle.Credentials.Single(c => c.Uuid == requestBody.Credential.Uuid);
+        AnonKeyBackend.Models.Credential NewCredential = databaseHandle.Credentials.Single(c => c.Uuid == requestBody.Credential.Uuid);
         return TypedResults.Ok(CronstructResponse(NewCredential));
     }
 
     private static CredentialsUpdateResponseBody CronstructResponse(Credential NewCredential)
     {
-        return new AnonKey_Backend.ApiDatastructures.Credentials.Update.CredentialsUpdateResponseBody()
+        return new AnonKeyBackend.ApiDatastructures.Credentials.Update.CredentialsUpdateResponseBody()
         {
-            Credential = new AnonKey_Backend.ApiDatastructures.Credentials.Update.CredentialsUpdateCredentialResponse()
+            Credential = new AnonKeyBackend.ApiDatastructures.Credentials.Update.CredentialsUpdateCredentialResponse()
             {
                 Uuid = NewCredential.Uuid,
                 FolderUuid = NewCredential.FolderUuid,
@@ -137,7 +137,7 @@ public static class Update
         };
     }
 
-    private static void UpdateCredential(CredentialsUpdateRequestBody requestBody, ClaimsPrincipal user, string? UserUuid, AnonKey_Backend.Models.Credential FetchedCredential)
+    private static void UpdateCredential(CredentialsUpdateRequestBody requestBody, ClaimsPrincipal user, string? UserUuid, AnonKeyBackend.Models.Credential FetchedCredential)
     {
         if (requestBody.Credential is not null)
         {

--- a/ApiEndpoints/EndpointSetup.cs
+++ b/ApiEndpoints/EndpointSetup.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiEndpoints;
+namespace AnonKeyBackend.ApiEndpoints;
 
 /// <summary>
 /// Handles mapping the API endpoints.

--- a/ApiEndpoints/Folders/Create.cs
+++ b/ApiEndpoints/Folders/Create.cs
@@ -1,9 +1,9 @@
-using AnonKey_Backend.ApiDatastructures.Folders.Create;
-using AnonKey_Backend.Data;
-using AnonKey_Backend.Models;
+using AnonKeyBackend.ApiDatastructures.Folders.Create;
+using AnonKeyBackend.Data;
+using AnonKeyBackend.Models;
 
 
-namespace AnonKey_Backend.ApiEndpoints.Folders;
+namespace AnonKeyBackend.ApiEndpoints.Folders;
 
 /// <summary>
 /// Handles the folders create endpoint.

--- a/ApiEndpoints/Folders/Delete.cs
+++ b/ApiEndpoints/Folders/Delete.cs
@@ -1,7 +1,7 @@
-using AnonKey_Backend.Data;
-using AnonKey_Backend.Models;
+using AnonKeyBackend.Data;
+using AnonKeyBackend.Models;
 
-namespace AnonKey_Backend.ApiEndpoints.Folders;
+namespace AnonKeyBackend.ApiEndpoints.Folders;
 
 /// <summary>
 /// Handles the folders delete endpoint.

--- a/ApiEndpoints/Folders/EndpointSetup.cs
+++ b/ApiEndpoints/Folders/EndpointSetup.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiEndpoints.Folders;
+namespace AnonKeyBackend.ApiEndpoints.Folders;
 
 /// <summary>
 /// Handles mapping the folders endpoints.

--- a/ApiEndpoints/Folders/Get.cs
+++ b/ApiEndpoints/Folders/Get.cs
@@ -1,6 +1,6 @@
-using AnonKey_Backend.Models;
+using AnonKeyBackend.Models;
 
-namespace AnonKey_Backend.ApiEndpoints.Folders;
+namespace AnonKeyBackend.ApiEndpoints.Folders;
 
 /// <summary>
 /// Handles the folders get endpoint. 

--- a/ApiEndpoints/Folders/GetAll.cs
+++ b/ApiEndpoints/Folders/GetAll.cs
@@ -1,8 +1,8 @@
-using AnonKey_Backend.ApiDatastructures.Folders.GetAll;
-using AnonKey_Backend.Data;
-using AnonKey_Backend.Models;
+using AnonKeyBackend.ApiDatastructures.Folders.GetAll;
+using AnonKeyBackend.Data;
+using AnonKeyBackend.Models;
 
-namespace AnonKey_Backend.ApiEndpoints.Folders;
+namespace AnonKeyBackend.ApiEndpoints.Folders;
 
 /// <summary>
 /// Handles the folders getall endpoint.
@@ -42,12 +42,12 @@ public static class GetAll
 
     private static FoldersGetAllResponseBody GetAllFolders(User userObject, DatabaseHandle databaseHandle)
     {
-        List<AnonKey_Backend.Models.Folder> fetchedFolders = databaseHandle.Folders.Where(f => f.UserUuid == userObject.Uuid).ToList();
-        AnonKey_Backend.ApiDatastructures.Folders.GetAll.FoldersGetAllResponseBody result = new AnonKey_Backend.ApiDatastructures.Folders.GetAll.FoldersGetAllResponseBody();
+        List<AnonKeyBackend.Models.Folder> fetchedFolders = databaseHandle.Folders.Where(f => f.UserUuid == userObject.Uuid).ToList();
+        AnonKeyBackend.ApiDatastructures.Folders.GetAll.FoldersGetAllResponseBody result = new AnonKeyBackend.ApiDatastructures.Folders.GetAll.FoldersGetAllResponseBody();
         result.Folder = new List<FoldersGetAllFolder>();
-        foreach (AnonKey_Backend.Models.Folder fetchedFolder in fetchedFolders)
+        foreach (AnonKeyBackend.Models.Folder fetchedFolder in fetchedFolders)
         {
-            result.Folder.Add(new AnonKey_Backend.ApiDatastructures.Folders.GetAll.FoldersGetAllFolder()
+            result.Folder.Add(new AnonKeyBackend.ApiDatastructures.Folders.GetAll.FoldersGetAllFolder()
             {
                 Uuid = fetchedFolder.Uuid,
                 Name = fetchedFolder.DisplayName,

--- a/ApiEndpoints/Folders/Update.cs
+++ b/ApiEndpoints/Folders/Update.cs
@@ -1,7 +1,7 @@
-using AnonKey_Backend.ApiDatastructures.Folders.Update;
-using AnonKey_Backend.Models;
+using AnonKeyBackend.ApiDatastructures.Folders.Update;
+using AnonKeyBackend.Models;
 
-namespace AnonKey_Backend.ApiEndpoints.Folders;
+namespace AnonKeyBackend.ApiEndpoints.Folders;
 
 /// <summary>
 /// Handles the folders update endpoint.

--- a/ApiEndpoints/Service/EndpointSetup.cs
+++ b/ApiEndpoints/Service/EndpointSetup.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiEndpoints.Service;
+namespace AnonKeyBackend.ApiEndpoints.Service;
 
 /// <summary>
 /// Handles mapping the service endpoints.

--- a/ApiEndpoints/Service/Ping.cs
+++ b/ApiEndpoints/Service/Ping.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiEndpoints.Service;
+namespace AnonKeyBackend.ApiEndpoints.Service;
 /// <summary>
 /// Handles the ping service endpoint.
 /// </summary>

--- a/ApiEndpoints/Users/Create.cs
+++ b/ApiEndpoints/Users/Create.cs
@@ -1,9 +1,9 @@
 using System.Text.RegularExpressions;
-using AnonKey_Backend.ApiDatastructures.Users.Create;
-using AnonKey_Backend.Authentication;
-using AnonKey_Backend.Data;
+using AnonKeyBackend.ApiDatastructures.Users.Create;
+using AnonKeyBackend.Authentication;
+using AnonKeyBackend.Data;
 
-namespace AnonKey_Backend.ApiEndpoints.Users;
+namespace AnonKeyBackend.ApiEndpoints.Users;
 
 /// <summary>
 /// Handles the users create endpoint.
@@ -17,7 +17,7 @@ public static class Create
         Ok<ApiDatastructures.Users.Create.UsersCreateResponseBody>,
         Conflict<ApiDatastructures.Error.ErrorResponseBody>,
         BadRequest<ApiDatastructures.Error.ErrorResponseBody>>
-           PostCreate(ApiDatastructures.Users.Create.UsersCreateRequestBody requestBody, AnonKey_Backend.Authentication.TokenService tokenService, Data.DatabaseHandle databaseHandle)
+           PostCreate(ApiDatastructures.Users.Create.UsersCreateRequestBody requestBody, AnonKeyBackend.Authentication.TokenService tokenService, Data.DatabaseHandle databaseHandle)
     {
         databaseHandle.Database.EnsureCreated();
         // if (requestBody.UserDisplayName is null || requestBody.KdfPasswordResult is null || requestBody.UserName is null)
@@ -59,7 +59,7 @@ public static class Create
         return TypedResults.Ok(new ApiDatastructures.Users.Create.UsersCreateResponseBody
         {
             Token = token,
-            ExpiresInSeconds = AnonKey_Backend.Authentication.TokenService.TokenExpiryGraceInSeconds
+            ExpiresInSeconds = AnonKeyBackend.Authentication.TokenService.TokenExpiryGraceInSeconds
         });
 
 

--- a/ApiEndpoints/Users/Delete.cs
+++ b/ApiEndpoints/Users/Delete.cs
@@ -1,7 +1,7 @@
-using AnonKey_Backend.Data;
-using AnonKey_Backend.Models;
+using AnonKeyBackend.Data;
+using AnonKeyBackend.Models;
 
-namespace AnonKey_Backend.ApiEndpoints.Users;
+namespace AnonKeyBackend.ApiEndpoints.Users;
 
 /// <summary>
 /// Handles the users delete endpoint.

--- a/ApiEndpoints/Users/EndpointSetup.cs
+++ b/ApiEndpoints/Users/EndpointSetup.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiEndpoints.Users;
+namespace AnonKeyBackend.ApiEndpoints.Users;
 
 /// <summary>
 /// Handles mapping the users endpoint.

--- a/ApiEndpoints/Users/Get.cs
+++ b/ApiEndpoints/Users/Get.cs
@@ -1,6 +1,6 @@
-using AnonKey_Backend.Models;
+using AnonKeyBackend.Models;
 
-namespace AnonKey_Backend.ApiEndpoints.Users;
+namespace AnonKeyBackend.ApiEndpoints.Users;
 
 /// <summary>
 /// Handles the users get endpoint.

--- a/ApiEndpoints/Users/Update.cs
+++ b/ApiEndpoints/Users/Update.cs
@@ -1,6 +1,6 @@
-using AnonKey_Backend.Models;
+using AnonKeyBackend.Models;
 
-namespace AnonKey_Backend.ApiEndpoints.Users;
+namespace AnonKeyBackend.ApiEndpoints.Users;
 
 /// <summary>
 /// Handles the users update endpoint.

--- a/ApiEndpoints/Uuid/EndpointSetup.cs
+++ b/ApiEndpoints/Uuid/EndpointSetup.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiEndpoints.Uuid;
+namespace AnonKeyBackend.ApiEndpoints.Uuid;
 
 /// <summary>
 /// Handles mapping the uuid endpoint.

--- a/ApiEndpoints/Uuid/NewUuid.cs
+++ b/ApiEndpoints/Uuid/NewUuid.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.ApiEndpoints.Uuid;
+namespace AnonKeyBackend.ApiEndpoints.Uuid;
 
 /// <summary>
 /// Handles the new uuid new endpoint.
@@ -11,7 +11,7 @@ public static class NewUuid
     /// </summary>
     public static Microsoft.AspNetCore.Http.HttpResults.Results<
         Ok<string>,
-        BadRequest<AnonKey_Backend.ApiDatastructures.Error.ErrorResponseBody>>
+        BadRequest<AnonKeyBackend.ApiDatastructures.Error.ErrorResponseBody>>
             GetNewUuid(ClaimsPrincipal user)
     {
         Guid newGuid = System.Guid.NewGuid();

--- a/Authentication/TokenService.cs
+++ b/Authentication/TokenService.cs
@@ -1,8 +1,8 @@
-using AnonKey_Backend.Models;
+using AnonKeyBackend.Models;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 
-namespace AnonKey_Backend.Authentication;
+namespace AnonKeyBackend.Authentication;
 
 /// <summary>
 /// The service provider for token generation.

--- a/Configuration/Settings.cs
+++ b/Configuration/Settings.cs
@@ -1,6 +1,6 @@
 #pragma warning disable CA1707
 using Newtonsoft.Json;
-namespace AnonKey_Backend.Configuration;
+namespace AnonKeyBackend.Configuration;
 
 // NOTE: This class contains public members that are prefixed with a _ and named in camelCase.
 //       While not beautiful, but is required for deserialization.

--- a/Cryptography/Generators.cs
+++ b/Cryptography/Generators.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.Cryptography;
+namespace AnonKeyBackend.Cryptography;
 using System.Security.Cryptography;
 
 /// <summary>

--- a/Cryptography/PasswordHashing.cs
+++ b/Cryptography/PasswordHashing.cs
@@ -1,6 +1,6 @@
 using Konscious.Security.Cryptography;
 using System.Text;
-namespace AnonKey_Backend.Cryptography;
+namespace AnonKeyBackend.Cryptography;
 
 /// <summary>
 /// Holds methods for hashing passwords, and checking the hashed passwords.

--- a/Data/DatabaseHandle.cs
+++ b/Data/DatabaseHandle.cs
@@ -1,7 +1,7 @@
-namespace AnonKey_Backend.Data;
+namespace AnonKeyBackend.Data;
 using Models;
 using Microsoft.EntityFrameworkCore;
-using AnonKey_Backend.Development;
+using AnonKeyBackend.Development;
 
 #nullable disable
 

--- a/Development/SampleData.cs
+++ b/Development/SampleData.cs
@@ -1,4 +1,4 @@
-namespace AnonKey_Backend.Development;
+namespace AnonKeyBackend.Development;
 using Microsoft.EntityFrameworkCore;
 
 /// <summary>
@@ -20,7 +20,7 @@ public static class ModelBuilderExtensions
     private static void CreateSampleUser(this ModelBuilder modelBuilder)
     {
         string passwordSalt = Cryptography.Generators.NewRandomString(Configuration.Settings.UserPasswordSaltLength);
-        modelBuilder.Entity<AnonKey_Backend.Models.User>().HasData(new AnonKey_Backend.Models.User
+        modelBuilder.Entity<AnonKeyBackend.Models.User>().HasData(new AnonKeyBackend.Models.User
         {
             Uuid = "7d9d3e99-064d-41bf-a125-ca5951e8a048",
             Username = "anonkey",
@@ -29,7 +29,7 @@ public static class ModelBuilderExtensions
         }
         );
 
-        modelBuilder.Entity<AnonKey_Backend.Models.UserInfo>().HasData(new AnonKey_Backend.Models.UserInfo
+        modelBuilder.Entity<AnonKeyBackend.Models.UserInfo>().HasData(new AnonKeyBackend.Models.UserInfo
         {
             Uuid = Guid.NewGuid().ToString(),
             UserUuid = "7d9d3e99-064d-41bf-a125-ca5951e8a048",
@@ -39,7 +39,7 @@ public static class ModelBuilderExtensions
 
     private static void CreateSampleFolder(this ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<AnonKey_Backend.Models.Folder>().HasData(new AnonKey_Backend.Models.Folder
+        modelBuilder.Entity<AnonKeyBackend.Models.Folder>().HasData(new AnonKeyBackend.Models.Folder
         {
             Uuid = "09f770c5-b1c1-41c6-bfd2-818b7b443da9",
             UserUuid = "7d9d3e99-064d-41bf-a125-ca5951e8a048",
@@ -50,7 +50,7 @@ public static class ModelBuilderExtensions
 
     private static void CreateSampleCredentialWithoutFolder(this ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<AnonKey_Backend.Models.Credential>().HasData(new AnonKey_Backend.Models.Credential
+        modelBuilder.Entity<AnonKeyBackend.Models.Credential>().HasData(new AnonKeyBackend.Models.Credential
         {
             Uuid = "ebd1ef35-cade-4e2a-8117-3ed58bd13143",
             UserUuid = "7d9d3e99-064d-41bf-a125-ca5951e8a048",
@@ -73,7 +73,7 @@ public static class ModelBuilderExtensions
 
     private static void CreateSampleCredentialInSampleFolder(this ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<AnonKey_Backend.Models.Credential>().HasData(new AnonKey_Backend.Models.Credential
+        modelBuilder.Entity<AnonKeyBackend.Models.Credential>().HasData(new AnonKeyBackend.Models.Credential
         {
             Uuid = "d59bd8a5-e24b-4b97-94f5-2e3dfb9a297e",
             UserUuid = "7d9d3e99-064d-41bf-a125-ca5951e8a048",

--- a/Models/Credential.cs
+++ b/Models/Credential.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel.DataAnnotations;
-namespace AnonKey_Backend.Models;
+namespace AnonKeyBackend.Models;
 
 /// <summary>
 /// A credetial model to be saved in a database

--- a/Models/Folder.cs
+++ b/Models/Folder.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel.DataAnnotations;
-namespace AnonKey_Backend.Models;
+namespace AnonKeyBackend.Models;
 
 /// <summary>
 /// A credetial model to be saved in a database

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel.DataAnnotations;
-namespace AnonKey_Backend.Models;
+namespace AnonKeyBackend.Models;
 
 /// <summary>
 /// Secret user information only meant for use in the backend.

--- a/Models/UserInfo.cs
+++ b/Models/UserInfo.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel.DataAnnotations;
-namespace AnonKey_Backend.Models;
+namespace AnonKeyBackend.Models;
 
 /// <summary>
 /// A user model to be saved in a database

--- a/Program.cs
+++ b/Program.cs
@@ -7,7 +7,7 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 
 
-namespace AnonKey_Backend;
+namespace AnonKeyBackend;
 
 #pragma warning disable
 
@@ -53,10 +53,10 @@ public class Program
 
 
         // Entity Framework / Database
-        builder.Services.AddEntityFrameworkSqlite().AddDbContext<AnonKey_Backend.Data.DatabaseHandle>(opt => opt.UseSqlite(builder.Configuration.GetConnectionString("ApiDatabase")));
+        builder.Services.AddEntityFrameworkSqlite().AddDbContext<AnonKeyBackend.Data.DatabaseHandle>(opt => opt.UseSqlite(builder.Configuration.GetConnectionString("ApiDatabase")));
 
         // Authentication
-        builder.Services.AddSingleton<Authentication.TokenService>();
+        builder.Services.AddSingleton<AnonKeyBackend.Authentication.TokenService>();
         builder.Services.AddAuthentication(config =>
                 {
                     config.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
@@ -92,7 +92,7 @@ public class Program
         app.UseAuthorization();
 
         // Initialize the endpoints with the proper mappings
-        AnonKey_Backend.ApiEndpoints.EndpointSetup.Initialize(app);
+        AnonKeyBackend.ApiEndpoints.EndpointSetup.Initialize(app);
 
         app.Run();
 


### PR DESCRIPTION
Renamed the root namespace from AnonKey_Backend to AnonKeyBackend to align with Roslyn styling guidelines.

Part of #93.